### PR TITLE
fix: hashmeddler

### DIFF
--- a/ethtxmanager/sqlstorage/meddler.go
+++ b/ethtxmanager/sqlstorage/meddler.go
@@ -153,27 +153,49 @@ func (m HashMeddler) PreRead(fieldAddr interface{}) (scanTarget interface{}, err
 }
 
 // PostRead is called after a Scan operation for fields that have the HashMeddler
-func (m HashMeddler) PostRead(fieldPtr, scanTarget interface{}) error {
-	ptr, ok := scanTarget.(*string)
+func (b HashMeddler) PostRead(fieldPtr, scanTarget interface{}) error {
+	rawHashPtr, ok := scanTarget.(*string)
 	if !ok {
 		return errors.New("scanTarget is not *string")
 	}
-	if ptr == nil {
-		return fmt.Errorf("HashMeddler.PostRead: nil pointer")
-	}
+
+	// Handle the case where fieldPtr is a *common.Hash
 	field, ok := fieldPtr.(*common.Hash)
-	if !ok {
-		return errors.New("fieldPtr is not common.Hash")
+	if ok {
+		*field = common.HexToHash(*rawHashPtr)
+		return nil
 	}
-	*field = common.HexToHash(*ptr)
-	return nil
+
+	// Handle the case where fieldPtr is a **common.Hash (nullable field)
+	hashPtr, ok := fieldPtr.(**common.Hash)
+	if ok {
+		// If the string is empty, set the hash to nil
+		if len(*rawHashPtr) == 0 {
+			*hashPtr = nil
+			// Otherwise, convert the string to a common.Hash and assign it
+		} else {
+			tmp := common.HexToHash(*rawHashPtr)
+			*hashPtr = &tmp
+		}
+		return nil
+	}
+
+	// If fieldPtr is neither a *common.Hash nor a **common.Hash, return an error
+	return errors.New("fieldPtr is not *common.Hash or **common.Hash")
 }
 
 // PreWrite is called before an Insert or Update operation for fields that have the HashMeddler
-func (m HashMeddler) PreWrite(fieldPtr interface{}) (saveValue interface{}, err error) {
+func (b HashMeddler) PreWrite(fieldPtr interface{}) (saveValue interface{}, err error) {
 	field, ok := fieldPtr.(common.Hash)
 	if !ok {
-		return nil, errors.New("fieldPtr is not common.Hash")
+		hashPtr, ok := fieldPtr.(*common.Hash)
+		if !ok {
+			return nil, errors.New("fieldPtr is not common.Hash")
+		}
+		if hashPtr == nil {
+			return []byte{}, nil
+		}
+		return hashPtr.Hex(), nil
 	}
 	return field.Hex(), nil
 }


### PR DESCRIPTION
This PR fixes an issue in the AggKit component where if some components which rely on `zkevm-ethtx-manager` repo is spun up before the AggSender, there will be an issue saving the PreviousLocalExitRoot because the type assertion is not yet implemented in this repo.

![Screenshot from 2025-01-22 09-30-43](https://github.com/user-attachments/assets/3b4625b6-0db3-4ba1-9423-4cc5a05be11a)

When the AggSender component is spun up first, this is not an issue, because the AggKit repository already has [checks](https://github.com/agglayer/aggkit/blob/main/db/meddler.go#L155-L201) for this. But when another component which has dependencies on zkevm-ethtx-manager is spun up first, the AggSender also uses the [HashMeddler](https://github.com/0xPolygon/zkevm-ethtx-manager/blob/main/ethtxmanager/sqlstorage/meddler.go#L155-L179) of the zkevm-ethtx-manager which causes the error.

## Testing
Tested on a local devnet with the changes and the error is gone and the bridging scenarios can be conducted without issues.
![Screenshot from 2025-01-24 22-08-25](https://github.com/user-attachments/assets/362a1c63-18c6-463a-87d0-b84cb70d1687)
![Screenshot from 2025-01-24 21-57-58](https://github.com/user-attachments/assets/54a6393b-e0b1-491e-8ad7-c8e1aea83fe1)
![Screenshot from 2025-01-24 22-34-19](https://github.com/user-attachments/assets/76ef08bf-58b4-4198-af84-52b26e6b2e4f)
