### PR TITLE
fix: fix pass a nil as a logger to signers

### DIFF
--- a/etherman/etherman_signers.go
+++ b/etherman/etherman_signers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/0xPolygon/zkevm-ethtx-manager/log"
 	"github.com/agglayer/go_signer/signer"
 	signertypes "github.com/agglayer/go_signer/signer/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -19,12 +20,13 @@ type EthermanSigners struct {
 // NewEthermanSigners creates a new instance of EthermanSigners
 func NewEthermanSigners(ctx context.Context, chainID uint64,
 	config []signertypes.SignerConfig) (*EthermanSigners, error) {
+	logger := log.WithFields("module", "eth-signer")
 	res := EthermanSigners{
 		chainID: chainID,
 		signers: make(map[common.Address]signertypes.Signer),
 	}
 	for i, signerConfig := range config {
-		signer, err := signer.NewSigner(ctx, chainID, signerConfig, fmt.Sprintf("signer-%d", i), nil)
+		signer, err := signer.NewSigner(ctx, chainID, signerConfig, fmt.Sprintf("signer-%d", i), logger)
 		if err != nil {
 			return nil, err
 		}

--- a/etherman/etherman_test.go
+++ b/etherman/etherman_test.go
@@ -153,6 +153,26 @@ func TestNewClient(t *testing.T) {
 	require.NotNil(t, sut)
 }
 
+func TestNewClientDefaultConfig(t *testing.T) {
+	mockEth := mocks.NewEthereumClient(t)
+	ethclientFactoryFunc = func(url string) (EthereumClient, error) {
+		return mockEth, nil
+	}
+	mockEth.EXPECT().ChainID(mock.Anything).Return(big.NewInt(1), nil)
+	sut, err := NewClient(Config{
+		URL: "http://localhost:8545",
+	}, []signertypes.SignerConfig{
+		{
+			Config: map[string]interface{}{
+				"path":     "test",
+				"password": "test",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, sut)
+}
+
 func TestPublicAddress(t *testing.T) {
 	mockSigner := mocks.NewSigner(t)
 	senderAddr := common.HexToAddress("0x1")


### PR DESCRIPTION
The etherman create signers with logger == nil and that produce an panic
Fixes: #115


