### PR TITLE
fix: meddler **common.Hash

### DIFF
--- a/ethtxmanager/sqlstorage/meddler.go
+++ b/ethtxmanager/sqlstorage/meddler.go
@@ -156,7 +156,7 @@ func (m HashMeddler) PreRead(fieldAddr interface{}) (scanTarget interface{}, err
 	}
 	return new(string), nil
 }
-func (b HashMeddler) PostReadDoulePtr(fieldPtr, scanTarget interface{}) error {
+func (b HashMeddler) postReadDoulePtr(fieldPtr, scanTarget interface{}) error {
 	rawHashPtr, ok := scanTarget.(**string)
 	if !ok {
 		return errors.New("scanTarget is not **string")
@@ -165,7 +165,6 @@ func (b HashMeddler) PostReadDoulePtr(fieldPtr, scanTarget interface{}) error {
 	hashPtr, ok := fieldPtr.(**common.Hash)
 	if ok {
 		if rawHashPtr == nil || *rawHashPtr == nil {
-			hashPtr = new(*common.Hash)
 			return nil
 		}
 		// If the string is empty, set the hash to nil
@@ -185,7 +184,7 @@ func (b HashMeddler) PostReadDoulePtr(fieldPtr, scanTarget interface{}) error {
 func (b HashMeddler) PostRead(fieldPtr, scanTarget interface{}) error {
 	_, ok := scanTarget.(**string)
 	if ok {
-		return b.PostReadDoulePtr(fieldPtr, scanTarget)
+		return b.postReadDoulePtr(fieldPtr, scanTarget)
 	}
 	rawHashPtr, ok := scanTarget.(*string)
 	if !ok {

--- a/ethtxmanager/sqlstorage/meddler.go
+++ b/ethtxmanager/sqlstorage/meddler.go
@@ -151,7 +151,7 @@ func (m HashMeddler) PreRead(fieldAddr interface{}) (scanTarget interface{}, err
 	// give a pointer to a byte buffer to grab the raw data
 	_, ok := fieldAddr.(**common.Hash)
 	if ok {
-		// This is becase if not the rows.Scan fails 'converting NULL to string is unsupported'
+		// This is because if not the rows.Scan fails 'converting NULL to string is unsupported'
 		return new(*string), nil
 	}
 	return new(string), nil

--- a/ethtxmanager/sqlstorage/meddler.go
+++ b/ethtxmanager/sqlstorage/meddler.go
@@ -149,11 +149,44 @@ type HashMeddler struct{}
 // PreRead is called before a Scan operation for fields that have the HashMeddler
 func (m HashMeddler) PreRead(fieldAddr interface{}) (scanTarget interface{}, err error) {
 	// give a pointer to a byte buffer to grab the raw data
+	_, ok := fieldAddr.(**common.Hash)
+	if ok {
+		// This is becase if not the rows.Scan fails 'converting NULL to string is unsupported'
+		return new(*string), nil
+	}
 	return new(string), nil
+}
+func (b HashMeddler) PostReadDoulePtr(fieldPtr, scanTarget interface{}) error {
+	rawHashPtr, ok := scanTarget.(**string)
+	if !ok {
+		return errors.New("scanTarget is not **string")
+	}
+	// Handle the case where fieldPtr is a **common.Hash (nullable field)
+	hashPtr, ok := fieldPtr.(**common.Hash)
+	if ok {
+		if rawHashPtr == nil || *rawHashPtr == nil {
+			hashPtr = new(*common.Hash)
+			return nil
+		}
+		// If the string is empty, set the hash to nil
+		if len(**rawHashPtr) == 0 {
+			*hashPtr = nil
+			// Otherwise, convert the string to a common.Hash and assign it
+		} else {
+			tmp := common.HexToHash(**rawHashPtr)
+			*hashPtr = &tmp
+		}
+		return nil
+	}
+	return errors.New("fieldPtr is not **common.Hash")
 }
 
 // PostRead is called after a Scan operation for fields that have the HashMeddler
 func (b HashMeddler) PostRead(fieldPtr, scanTarget interface{}) error {
+	_, ok := scanTarget.(**string)
+	if ok {
+		return b.PostReadDoulePtr(fieldPtr, scanTarget)
+	}
 	rawHashPtr, ok := scanTarget.(*string)
 	if !ok {
 		return errors.New("scanTarget is not *string")
@@ -165,23 +198,8 @@ func (b HashMeddler) PostRead(fieldPtr, scanTarget interface{}) error {
 		*field = common.HexToHash(*rawHashPtr)
 		return nil
 	}
-
-	// Handle the case where fieldPtr is a **common.Hash (nullable field)
-	hashPtr, ok := fieldPtr.(**common.Hash)
-	if ok {
-		// If the string is empty, set the hash to nil
-		if len(*rawHashPtr) == 0 {
-			*hashPtr = nil
-			// Otherwise, convert the string to a common.Hash and assign it
-		} else {
-			tmp := common.HexToHash(*rawHashPtr)
-			*hashPtr = &tmp
-		}
-		return nil
-	}
-
 	// If fieldPtr is neither a *common.Hash nor a **common.Hash, return an error
-	return errors.New("fieldPtr is not *common.Hash or **common.Hash")
+	return errors.New("fieldPtr is not *common.Hash")
 }
 
 // PreWrite is called before an Insert or Update operation for fields that have the HashMeddler

--- a/ethtxmanager/sqlstorage/meddler_test.go
+++ b/ethtxmanager/sqlstorage/meddler_test.go
@@ -1,0 +1,65 @@
+package sqlstorage
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/russross/meddler"
+	"github.com/stretchr/testify/require"
+)
+
+type certificateInfo struct {
+	Height                  uint64       `meddler:"height"`
+	CertificateID           common.Hash  `meddler:"certificate_id,hash"`
+	FinalizedL1InfoTreeRoot *common.Hash `meddler:"finalized_l1_info_tree_root,hash"`
+}
+
+func TestMeddlerHashPointerIsNull(t *testing.T) {
+	initMeddler()
+	db := createExampleDB(t)
+	var certificateInfo certificateInfo
+	err := meddler.QueryRow(db, &certificateInfo, "SELECT * FROM certificate_info where height=0;")
+	require.NoError(t, err, "null case")
+	require.Nil(t, certificateInfo.FinalizedL1InfoTreeRoot, "FinalizedL1InfoTreeRoot should be nil for height 0")
+	fmt.Print(certificateInfo)
+
+}
+
+func TestMeddlerHashPointerIsNotNull(t *testing.T) {
+	initMeddler()
+	db := createExampleDB(t)
+	var certificateInfo certificateInfo
+	err := meddler.QueryRow(db, &certificateInfo, "SELECT * FROM certificate_info where height=1;")
+	require.NoError(t, err, "data case")
+	require.NotNil(t, certificateInfo.FinalizedL1InfoTreeRoot, "FinalizedL1InfoTreeRoot should not be nil for height 1")
+	fmt.Print(certificateInfo)
+}
+
+func createExampleDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dbPath := ":memory:"
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE TABLE certificate_info (
+			height INTEGER PRIMARY KEY,
+			certificate_id VARCHAR NOT NULL,
+			finalized_l1_info_tree_root VARCHAR
+		);
+	`)
+	require.NoError(t, err, "failed to create table")
+	_, err = db.Exec(`
+	INSERT INTO certificate_info (height, certificate_id,finalized_l1_info_tree_root) 
+	VALUES (0,'0xbeef', NULL);
+`)
+	require.NoError(t, err, "failed to insert null data")
+	_, err = db.Exec(`
+		INSERT INTO certificate_info (height,certificate_id, finalized_l1_info_tree_root) 
+		VALUES (1, '0xbeef','0x1234567890123456789012345678901234567890');
+	`)
+	require.NoError(t, err, "failed to insert data")
+	return db
+}


### PR DESCRIPTION
Closes #128.

It implement the case of reading from database a null value in a field of type `**common.Hash` using **meddler**